### PR TITLE
Event handler for action.triggered events

### DIFF
--- a/eventhandlers.go
+++ b/eventhandlers.go
@@ -1,9 +1,10 @@
 package main
 
 import (
+	"log"
+
 	"github.com/cloudevents/sdk-go/pkg/cloudevents"
 	keptn "github.com/keptn/go-utils/pkg/lib"
-	"log"
 )
 
 /**
@@ -99,12 +100,12 @@ func HandleActionTriggeredEvent(myKeptn *keptn.Keptn, incomingEvent cloudevents.
 	log.Printf("Handling Action Triggered Event: %s", incomingEvent.Context.GetID())
 
 	// check if action is supported
-	if(data.Action.Action == "action-xyz") {
-		//myKeptn.SendActionStartedEvent()
+	if data.Action.Action == "action-xyz" {
+		//myKeptn.SendActionStartedEvent() TODO: implement the SendActionStartedEvent in keptn/go-utils/pkg/lib/events.go
 
 		// Implement your remediation action here
 
-		//myKeptn.SendActionFinishedEvent()
+		//myKeptn.SendActionFinishedEvent() TODO: implement the SendActionFinishedEvent in keptn/go-utils/pkg/lib/events.go
 	}
 	return nil
 }

--- a/eventhandlers.go
+++ b/eventhandlers.go
@@ -16,7 +16,8 @@ import (
   -> "sh.keptn.event.start-evaluation"
   -> "sh.keptn.events.evaluation-done"
   -> "sh.keptn.event.problem.open"
-  -> "sh.keptn.events.problem"
+	-> "sh.keptn.events.problem"
+	-> "sh.keptn.event.action.triggered"
 */
 
 //
@@ -85,5 +86,25 @@ func HandleEvaluationDoneEvent(myKeptn *keptn.Keptn, incomingEvent cloudevents.E
 func HandleProblemEvent(myKeptn *keptn.Keptn, incomingEvent cloudevents.Event, data *keptn.ProblemEventData) error {
 	log.Printf("Handling Problem Event: %s", incomingEvent.Context.GetID())
 
+	// Deprecated since Keptn 0.7.0 - use the HandleActionTriggeredEvent instead
+
+	return nil
+}
+
+//
+// Handles ActionTriggeredEventType = "sh.keptn.event.action.triggered"
+// TODO: add in your handler code
+//
+func HandleActionTriggeredEvent(myKeptn *keptn.Keptn, incomingEvent cloudevents.Event, data *keptn.ActionTriggeredEventData) error {
+	log.Printf("Handling Action Triggered Event: %s", incomingEvent.Context.GetID())
+
+	// check if action is supported
+	if(data.Action.Action == "action-xyz") {
+		//myKeptn.SendActionStartedEvent()
+
+		// Implement your remediation action here
+
+		//myKeptn.SendActionFinishedEvent()
+	}
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,8 @@ go 1.13
 require (
 	github.com/cloudevents/sdk-go v1.1.2
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/keptn/go-utils v0.6.1-compat
+	github.com/keptn/go-utils v0.6.3-0.20200615074910-2565441cb79d
 	github.com/onsi/ginkgo v1.12.0 // indirect
 	github.com/onsi/gomega v1.9.0 // indirect
-	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829 // indirect
 	golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9 // indirect
-	honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -148,6 +148,10 @@ github.com/keptn/go-utils v0.6.1-0.20200402095926-a4ac0d7044a0/go.mod h1:aDNFm3o
 github.com/keptn/go-utils v0.6.1-compat h1:Uqd0fmbPRxIqXpRv4q/q/O+KjAnJa+moZ85H19QN7oE=
 github.com/keptn/go-utils v0.6.1-compat/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
 github.com/keptn/go-utils v0.6.1 h1:ukBe1qtBiUyltabVMhTsx09pwlQTTRn3hJJc/XD81EY=
+github.com/keptn/go-utils v0.6.2 h1:QpnshZ6cv64T+RZaLaqw6WEnKwV/A1YN3AVLrckva6k=
+github.com/keptn/go-utils v0.6.2/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
+github.com/keptn/go-utils v0.6.3-0.20200615074910-2565441cb79d h1:VtFkwEEXBCKnp67X4Dy4y6ZVu+r2X9juDDexgtZl0Sc=
+github.com/keptn/go-utils v0.6.3-0.20200615074910-2565441cb79d/go.mod h1:hf2FU6JFuOzLP5rEAlA1/XnNS28pDZbVfxDESeQsq1g=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=

--- a/main.go
+++ b/main.go
@@ -104,6 +104,8 @@ func processKeptnCloudEvent(ctx context.Context, event cloudevents.Event) error 
 
 		return HandleEvaluationDoneEvent(myKeptn, event, evaluationDoneEventData)
 	} else if event.Type() == keptn.ProblemOpenEventType || event.Type() == keptn.ProblemEventType {
+		// Subscribing to a problem.open or problem event is deprecated since Keptn 0.7 - subscribe to sh.keptn.event.action.triggered
+		log.Printf("Subscribing to a problem.open or problem event is not recommended since Keptn 0.7. Please subscribe to event of type: sh.keptn.event.action.triggered")
 		log.Printf("Processing Problem Event")
 
 		problemEventData := &keptn.ProblemEventData{}
@@ -114,6 +116,17 @@ func processKeptnCloudEvent(ctx context.Context, event cloudevents.Event) error 
 		}
 
 		return HandleProblemEvent(myKeptn, event, problemEventData)
+	} else if event.Type() == keptn.ActionTriggeredEventType {
+		log.Printf("Processing Action Triggered Event")
+
+		actionTriggeredEventData := &keptn.ActionTriggeredEventData{}
+		err := event.DataAs(actionTriggeredEventData)
+		if err != nil {
+			log.Printf("Got Data Error: %s", err.Error())
+			return err
+		}
+
+		return HandleActionTriggeredEvent(myKeptn, event, actionTriggeredEventData)
 	}
 
 	// Unknown Event -> Throw Error!


### PR DESCRIPTION
To help building action-providers for custom remediation use-cases, an event handler for the `sh.keptn.event.action.triggered` event is required and added by this PR. The implementation of the SendActionStartedEvent() and SendActionFinishedEvent() is marked as ToDo since it requires an update of the go-utils package. 