### PR TITLE
Fix distributor pubsub topic in service.yaml

### DIFF
--- a/deploy/service.yaml
+++ b/deploy/service.yaml
@@ -47,7 +47,7 @@ spec:
             - name: PUBSUB_URL
               value: 'nats://keptn-nats-cluster'
             - name: PUBSUB_TOPIC
-              value: 'sh.keptn.event.action.triggered'
+              value: 'sh.keptn.>'
             - name: PUBSUB_RECIPIENT
               value: '127.0.0.1'
 ---


### PR DESCRIPTION
this PR changes the distributor pubsub topic to listen to anything below `sh.keptn`.

In https://github.com/keptn-sandbox/keptn-service-template-go/commit/2b06a33bf65f62e9fba7c088d5aec2e102d353d3#diff-477fef38c302509bf025ac73a178bd07L77-R50 this was changed by accident.