### PR TITLE
#20 Upgrade to v0.7.2 of go-utils to reach compatibility with Keptn 0.7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ This implements a keptn-service-template-go for Keptn. If you want to learn more
 |:----------------:|:----------------------------------------:|
 |       0.6.1      | keptnsandbox/keptn-service-template-go:0.1.0 |
 |       0.7.1      | keptnsandbox/keptn-service-template-go:0.1.1 |
+|       0.7.2      | keptnsandbox/keptn-service-template-go:0.1.2 |
 
 ## Installation
 

--- a/eventhandler_test.go
+++ b/eventhandler_test.go
@@ -6,8 +6,8 @@ import (
 	"io/ioutil"
 	"testing"
 
-	_ "github.com/keptn/go-utils/pkg/lib"
-	keptn "github.com/keptn/go-utils/pkg/lib"
+	keptnlib "github.com/keptn/go-utils/pkg/lib"
+	keptn "github.com/keptn/go-utils/pkg/lib/keptn"
 
 	"github.com/cloudevents/sdk-go/pkg/cloudevents"
 )
@@ -15,7 +15,7 @@ import (
 /**
  * loads a cloud event from the passed test json file and initializes a keptn object with it
  */
-func initializeTestObjects(eventFileName string) (*keptn.Keptn, *cloudevents.Event, error) {
+func initializeTestObjects(eventFileName string) (*keptnlib.Keptn, *cloudevents.Event, error) {
 	// load sample event
 	eventFile, err := ioutil.ReadFile(eventFileName)
 	if err != nil {
@@ -30,7 +30,7 @@ func initializeTestObjects(eventFileName string) (*keptn.Keptn, *cloudevents.Eve
 
 	var keptnOptions = keptn.KeptnOpts{}
 	keptnOptions.UseLocalFileSystem = true
-	myKeptn, err := keptn.NewKeptn(incomingEvent, keptnOptions)
+	myKeptn, err := keptnlib.NewKeptn(incomingEvent, keptnOptions)
 
 	return myKeptn, incomingEvent, err
 }
@@ -43,7 +43,7 @@ func TestHandleConfigureMonitoringEvent(t *testing.T) {
 		return
 	}
 
-	specificEvent := &keptn.ConfigureMonitoringEventData{}
+	specificEvent := &keptnlib.ConfigureMonitoringEventData{}
 	err = incomingEvent.DataAs(specificEvent)
 	if err != nil {
 		t.Errorf("Error getting keptn event data")
@@ -66,7 +66,7 @@ func TestHandleConfigurationChangeEvent(t *testing.T) {
 		return
 	}
 
-	specificEvent := &keptn.ConfigurationChangeEventData{}
+	specificEvent := &keptnlib.ConfigurationChangeEventData{}
 	err = incomingEvent.DataAs(specificEvent)
 	if err != nil {
 		t.Errorf("Error getting keptn event data")
@@ -89,7 +89,7 @@ func TestHandleDeploymentFinishedEvent(t *testing.T) {
 		return
 	}
 
-	specificEvent := &keptn.DeploymentFinishedEventData{}
+	specificEvent := &keptnlib.DeploymentFinishedEventData{}
 	err = incomingEvent.DataAs(specificEvent)
 	if err != nil {
 		t.Errorf("Error getting keptn event data")
@@ -112,7 +112,7 @@ func TestHandleTestsFinishedEvent(t *testing.T) {
 		return
 	}
 
-	specificEvent := &keptn.TestsFinishedEventData{}
+	specificEvent := &keptnlib.TestsFinishedEventData{}
 	err = incomingEvent.DataAs(specificEvent)
 	if err != nil {
 		t.Errorf("Error getting keptn event data")
@@ -135,7 +135,7 @@ func TestHandleStartEvaluationEvent(t *testing.T) {
 		return
 	}
 
-	specificEvent := &keptn.StartEvaluationEventData{}
+	specificEvent := &keptnlib.StartEvaluationEventData{}
 	err = incomingEvent.DataAs(specificEvent)
 	if err != nil {
 		t.Errorf("Error getting keptn event data")
@@ -158,7 +158,7 @@ func TestHandleEvaluationDoneEvent(t *testing.T) {
 		return
 	}
 
-	specificEvent := &keptn.EvaluationDoneEventData{}
+	specificEvent := &keptnlib.EvaluationDoneEventData{}
 	err = incomingEvent.DataAs(specificEvent)
 	if err != nil {
 		t.Errorf("Error getting keptn event data")
@@ -178,7 +178,7 @@ func TestHandleInternalGetSLIEvent(t *testing.T) {
 		return
 	}
 
-	specificEvent := &keptn.InternalGetSLIEventData{}
+	specificEvent := &keptnlib.InternalGetSLIEventData{}
 	err = incomingEvent.DataAs(specificEvent)
 	if err != nil {
 		t.Errorf("Error getting keptn event data")
@@ -202,7 +202,7 @@ func TestHandleProblemEvent(t *testing.T) {
 		return
 	}
 
-	specificEvent := &keptn.ProblemEventData{}
+	specificEvent := &keptnlib.ProblemEventData{}
 	err = incomingEvent.DataAs(specificEvent)
 	if err != nil {
 		t.Errorf("Error getting keptn event data")
@@ -225,7 +225,7 @@ func TestHandleActionTriggeredEvent(t *testing.T) {
 		return
 	}
 
-	specificEvent := &keptn.ActionTriggeredEventData{}
+	specificEvent := &keptnlib.ActionTriggeredEventData{}
 	err = incomingEvent.DataAs(specificEvent)
 	if err != nil {
 		t.Errorf("Error getting keptn event data")

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,7 @@ go 1.13
 require (
 	github.com/cloudevents/sdk-go v1.1.2
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/keptn/go-utils v0.6.3-0.20200828090559-595b01d0f2a6
+	github.com/keptn/go-utils v0.7.2-alpha
 	github.com/onsi/ginkgo v1.12.0 // indirect
 	github.com/onsi/gomega v1.9.0 // indirect
-	golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cloudevents/sdk-go v0.10.0/go.mod h1:PW8UwWI6tD2Ry5kFpZfV1qlrADFkfaDCZXLiJ1dC1Ks=
 github.com/cloudevents/sdk-go v1.1.2 h1:mg/7d+BzubBPrPpH1bdeF85BQZYV85j7Ljqat3+m+qE=
 github.com/cloudevents/sdk-go v1.1.2/go.mod h1:ss+jWJ88wypiewnPEzChSBzTYXGpdcILoN9YHk8uhTQ=
+github.com/cloudevents/sdk-go/v2 v2.2.0/go.mod h1:3CTrpB4+u7Iaj6fd7E2Xvm5IxMdRoaAhqaRVnOr2rCU=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -135,6 +137,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.8.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.3 h1:YPkqC67at8FYaadspW/6uE0COsBxS2656RLEr8Bppgk=
+github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
@@ -154,6 +158,9 @@ github.com/keptn/go-utils v0.6.3-0.20200615074910-2565441cb79d h1:VtFkwEEXBCKnp6
 github.com/keptn/go-utils v0.6.3-0.20200615074910-2565441cb79d/go.mod h1:hf2FU6JFuOzLP5rEAlA1/XnNS28pDZbVfxDESeQsq1g=
 github.com/keptn/go-utils v0.6.3-0.20200828090559-595b01d0f2a6 h1:WJhNkXBLFZ6OxDziWFUuHmHuXmApVmvU0X2QrGySVDY=
 github.com/keptn/go-utils v0.6.3-0.20200828090559-595b01d0f2a6/go.mod h1:hf2FU6JFuOzLP5rEAlA1/XnNS28pDZbVfxDESeQsq1g=
+github.com/keptn/go-utils v0.7.1 h1:qDViu8qhijdh7QK1+k+i4hEDtTwkHo2PxsomxKvxlpg=
+github.com/keptn/go-utils v0.7.2-alpha h1:yoTmI6Od47AjPxGZNsns/ZGWl4mO5a0+bWEuvy1SuJ4=
+github.com/keptn/go-utils v0.7.2-alpha/go.mod h1:jD+ZvrkwYyDMgeKANzVZsBSYgjYQxTJvxw/RB3vYFAE=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
@@ -164,6 +171,7 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/lightstep/tracecontext.go v0.0.0-20181129014701-1757c391b1ac h1:+2b6iGRJe3hvV/yVXrd41yVEjxuFHxasJqDhkIjS4gk=
 github.com/lightstep/tracecontext.go v0.0.0-20181129014701-1757c391b1ac/go.mod h1:Frd2bnT3w5FB5q49ENTfVlztJES+1k/7lyWX2+9gq/M=
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
@@ -186,11 +194,14 @@ github.com/nats-io/nkeys v0.0.2/go.mod h1:dab7URMsZm6Z/jp9Z5UGa87Uutgc2mVpXLC4B7
 github.com/nats-io/nkeys v0.1.0/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nkeys v0.1.3/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
+github.com/onsi/ginkgo v1.10.2/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.0 h1:Iw5WCbBcaAAd0fpRb1c9r5YCylv4XDoCSigm1zLevwU=
 github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0HfGg=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.9.0 h1:R1uwffexN6Pr340GtYRIdZmAiN4J+iw6WG4wog1DUXg=
 github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
@@ -200,6 +211,8 @@ github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
@@ -223,6 +236,7 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
@@ -284,6 +298,7 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -300,6 +315,7 @@ golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9 h1:1/DFK4b7JH8DmkqhUk48onnSfrPzImPoVxuomtbT2nk=
 golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
@@ -343,6 +359,7 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=

--- a/main.go
+++ b/main.go
@@ -7,7 +7,8 @@ import (
 	"log"
 	"os"
 
-	keptn "github.com/keptn/go-utils/pkg/lib"
+	keptnlib "github.com/keptn/go-utils/pkg/lib"
+	keptn "github.com/keptn/go-utils/pkg/lib/keptn"
 
 	"github.com/cloudevents/sdk-go/pkg/cloudevents"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/client"
@@ -36,7 +37,7 @@ type envConfig struct {
  * See https://github.com/keptn/spec/blob/0.1.3/cloudevents.md for details on the payload
  */
 func processKeptnCloudEvent(ctx context.Context, event cloudevents.Event) error {
-	myKeptn, err := keptn.NewKeptn(&event, keptnOptions)
+	myKeptn, err := keptnlib.NewKeptn(&event, keptnOptions)
 
 	log.Printf("gotEvent(%s): %s - %s", event.Type(), myKeptn.KeptnContext, event.Context.GetID())
 
@@ -48,10 +49,10 @@ func processKeptnCloudEvent(ctx context.Context, event cloudevents.Event) error 
 	// ********************************************
 	// Lets test on each possible Event Type and call the respective handler function
 	// ********************************************
-	if event.Type() == keptn.ConfigurationChangeEventType {
+	if event.Type() == keptnlib.ConfigurationChangeEventType {
 		log.Printf("Processing Configuration Change Event")
 
-		configChangeEventData := &keptn.ConfigurationChangeEventData{}
+		configChangeEventData := &keptnlib.ConfigurationChangeEventData{}
 		err := event.DataAs(configChangeEventData)
 		if err != nil {
 			log.Printf("Got Data Error: %s", err.Error())
@@ -59,10 +60,10 @@ func processKeptnCloudEvent(ctx context.Context, event cloudevents.Event) error 
 		}
 
 		return HandleConfigurationChangeEvent(myKeptn, event, configChangeEventData)
-	} else if event.Type() == keptn.DeploymentFinishedEventType {
+	} else if event.Type() == keptnlib.DeploymentFinishedEventType {
 		log.Printf("Processing Deployment Finished Event")
 
-		deployFinishEventData := &keptn.DeploymentFinishedEventData{}
+		deployFinishEventData := &keptnlib.DeploymentFinishedEventData{}
 		err := event.DataAs(deployFinishEventData)
 		if err != nil {
 			log.Printf("Got Data Error: %s", err.Error())
@@ -70,10 +71,10 @@ func processKeptnCloudEvent(ctx context.Context, event cloudevents.Event) error 
 		}
 
 		return HandleDeploymentFinishedEvent(myKeptn, event, deployFinishEventData)
-	} else if event.Type() == keptn.TestsFinishedEventType {
+	} else if event.Type() == keptnlib.TestsFinishedEventType {
 		log.Printf("Processing Test Finished Event")
 
-		testsFinishedEventData := &keptn.TestsFinishedEventData{}
+		testsFinishedEventData := &keptnlib.TestsFinishedEventData{}
 		err := event.DataAs(testsFinishedEventData)
 		if err != nil {
 			log.Printf("Got Data Error: %s", err.Error())
@@ -81,10 +82,10 @@ func processKeptnCloudEvent(ctx context.Context, event cloudevents.Event) error 
 		}
 
 		return HandleTestsFinishedEvent(myKeptn, event, testsFinishedEventData)
-	} else if event.Type() == keptn.StartEvaluationEventType {
+	} else if event.Type() == keptnlib.StartEvaluationEventType {
 		log.Printf("Processing Start Evaluation Event")
 
-		startEvaluationEventData := &keptn.StartEvaluationEventData{}
+		startEvaluationEventData := &keptnlib.StartEvaluationEventData{}
 		err := event.DataAs(startEvaluationEventData)
 		if err != nil {
 			log.Printf("Got Data Error: %s", err.Error())
@@ -92,10 +93,10 @@ func processKeptnCloudEvent(ctx context.Context, event cloudevents.Event) error 
 		}
 
 		return HandleStartEvaluationEvent(myKeptn, event, startEvaluationEventData)
-	} else if event.Type() == keptn.EvaluationDoneEventType {
+	} else if event.Type() == keptnlib.EvaluationDoneEventType {
 		log.Printf("Processing Evaluation Done Event")
 
-		evaluationDoneEventData := &keptn.EvaluationDoneEventData{}
+		evaluationDoneEventData := &keptnlib.EvaluationDoneEventData{}
 		err := event.DataAs(evaluationDoneEventData)
 		if err != nil {
 			log.Printf("Got Data Error: %s", err.Error())
@@ -103,12 +104,12 @@ func processKeptnCloudEvent(ctx context.Context, event cloudevents.Event) error 
 		}
 
 		return HandleEvaluationDoneEvent(myKeptn, event, evaluationDoneEventData)
-	} else if event.Type() == keptn.ProblemOpenEventType || event.Type() == keptn.ProblemEventType {
+	} else if event.Type() == keptnlib.ProblemOpenEventType || event.Type() == keptnlib.ProblemEventType {
 		// Subscribing to a problem.open or problem event is deprecated since Keptn 0.7 - subscribe to sh.keptn.event.action.triggered
 		log.Printf("Subscribing to a problem.open or problem event is not recommended since Keptn 0.7. Please subscribe to event of type: sh.keptn.event.action.triggered")
 		log.Printf("Processing Problem Event")
 
-		problemEventData := &keptn.ProblemEventData{}
+		problemEventData := &keptnlib.ProblemEventData{}
 		err := event.DataAs(problemEventData)
 		if err != nil {
 			log.Printf("Got Data Error: %s", err.Error())
@@ -116,10 +117,10 @@ func processKeptnCloudEvent(ctx context.Context, event cloudevents.Event) error 
 		}
 
 		return HandleProblemEvent(myKeptn, event, problemEventData)
-	} else if event.Type() == keptn.ActionTriggeredEventType {
+	} else if event.Type() == keptnlib.ActionTriggeredEventType {
 		log.Printf("Processing Action Triggered Event")
 
-		actionTriggeredEventData := &keptn.ActionTriggeredEventData{}
+		actionTriggeredEventData := &keptnlib.ActionTriggeredEventData{}
 		err := event.DataAs(actionTriggeredEventData)
 		if err != nil {
 			log.Printf("Got Data Error: %s", err.Error())
@@ -127,10 +128,10 @@ func processKeptnCloudEvent(ctx context.Context, event cloudevents.Event) error 
 		}
 
 		return HandleActionTriggeredEvent(myKeptn, event, actionTriggeredEventData)
-	} else if event.Type() == keptn.ConfigureMonitoringEventType {
+	} else if event.Type() == keptnlib.ConfigureMonitoringEventType {
 		log.Printf("Processing Configure Monitoring Event")
 
-		configureMonitoringEventData := &keptn.ConfigureMonitoringEventData{}
+		configureMonitoringEventData := &keptnlib.ConfigureMonitoringEventData{}
 		err := event.DataAs(configureMonitoringEventData)
 		if err != nil {
 			log.Printf("Got Data Error: %s", err.Error())


### PR DESCRIPTION
This pr solves the first part of #20 and uses the new version of go-utils for Keptn 0.7.2 (and going forward, 0.7.3).