### PR TITLE
Add main branch to CI workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,11 +4,13 @@ on:
   push:
     branches:
       - 'master'
+      - 'main'
       - 'release-*'
   # in addition, execute for pull requests to those branches
   pull_request:
     branches:
       - 'master'
+      - 'main'
       - 'release-*'
 defaults:
   run:


### PR DESCRIPTION
This PR adds `main` as a target branch for the CI workflow.