### PR TITLE
Add fallback setting for get-previous-tag action

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -52,6 +52,8 @@ jobs:
       - name: 'Get Previous tag'
         id: get_previous_tag
         uses: "WyriHaximus/github-action-get-previous-tag@v1.1"
+        with:
+          fallback: "0.0.1"
       - name: 'Get next patch version'
         id: get_next_semver_tag
         uses: "WyriHaximus/github-action-next-semvers@v1.1"


### PR DESCRIPTION
This adds the new fallback option for the get-previous-tag action.

Fixes #41