### PR TITLE
feat: docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,21 @@
+
+version: '3.7'
+services:
+  keptn-service:
+    container_name: 'keptn-service-template-go'
+    build: .
+    depends_on:
+      - 'distributor'
+    ports:
+      - '8080:8080'
+    environment:
+      - CONFIGURATION_SERVICE=http://configuration-service:8080
+  distributor:
+    image: 'keptn/distributor:0.8.3'
+    container_name: 'keptn-distributor'
+    ports:
+      - '8080'
+    environment:
+      - PUBSUB_URL=nats://keptn-nats-cluster
+      - PUBSUB_TOPIC=sh.keptn.>
+      - PUBSUB_RECIPIENT=127.0.0.1


### PR DESCRIPTION
- Fixes #55 

This allows the user to run the distributor and the service locally by running `docker-compose up`
but inorder for the distributor to access the keptn-nats-cluster, the user has to create a load-balancer that exposes the nat temporarily.

The deployment of the load-balancer can be like:

```yaml
apiVersion: v1
kind: Service
metadata:
  name: keptn-nats-lb
  namespace: keptn
spec:
  type: LoadBalancer
  externalTrafficPolicy: Local
  selector:
    app: keptn-nats-cluster
  ports:
    - protocol: TCP
      port: 4222
      targetPort: 4222
      name: client
    - protocol: TCP
      port: 7422
      targetPort: 7422
      name: leafnodes
```

The user can get an `EXTERNAL_IP:PORT` and can replace the `PUB_URL` in the `docker-compose.yaml` file.

The whole process can be automated with a bash script. Should we include it?