### PR TITLE
feat: Added Keptn 0.11 support

### DIFF
--- a/deploy/service.yaml
+++ b/deploy/service.yaml
@@ -36,18 +36,6 @@ spec:
               value: 'http://configuration-service:8080'
         - name: distributor
           image: keptn/distributor:0.11.2
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: 10999
-            initialDelaySeconds: 0
-            periodSeconds: 5
-          readinessProbe:
-            httpGet:
-              path: /health
-              port: 10999
-            initialDelaySeconds: 5
-            periodSeconds: 5
           imagePullPolicy: Always
           ports:
             - containerPort: 8080

--- a/deploy/service.yaml
+++ b/deploy/service.yaml
@@ -35,7 +35,7 @@ spec:
             - name: CONFIGURATION_SERVICE
               value: 'http://configuration-service:8080'
         - name: distributor
-          image: keptn/distributor:0.10.0
+          image: keptn/distributor:0.11.2
           livenessProbe:
             httpGet:
               path: /health


### PR DESCRIPTION
## This PR

- Uses keptn/distributor 0.11.2
- Removes readiness and livenessprobes from distributor, as they are no longer needed / available

FYI @RealAnna and @thisthat

