### PR TITLE
fix: use keptn/distributor 0.11.4 in helm charts and skaffold

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -13,7 +13,7 @@ distributor:
   image:
     repository: docker.io/keptn/distributor  # Container Image Name
     pullPolicy: IfNotPresent                 # Kubernetes Image Pull Policy
-    tag: ""                                  # Container Tag
+    tag: "0.11.4"                            # Container Tag
 
 remoteControlPlane:
   enabled: false                             # Enables remote execution plane mode

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
     environment:
       - CONFIGURATION_SERVICE=http://configuration-service:8080
   distributor:
-    image: 'keptn/distributor:0.11.3'
+    image: 'keptn/distributor:0.11.4'
     container_name: 'keptn-distributor'
     ports:
       - '8080'

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -23,7 +23,7 @@ deploy:
         overrides:
           distributor:
             image:
-              tag: 0.10.0
+              tag: 0.11.4
           resources:
             limits:
               memory: 512Mi


### PR DESCRIPTION
Signed-off-by: Christian Kreuzberger <christian.kreuzberger@dynatrace.com>

Fixes #93 