### PR TITLE
feat: Upgrade to Keptn 0.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,13 @@ This implements a keptn-service-template-go for Keptn. If you want to learn more
 
 *Please fill in your versions accordingly*
 
-| Keptn Version    | [Keptn-Service-Template-Go Docker Image](https://hub.docker.com/r/keptn-sandbox/keptn-service-template-go/tags) |
-|:----------------:|:----------------------------------------:|
-|       0.6.1      | keptn-sandbox/keptn-service-template-go:0.1.0 |
-|       0.7.1      | keptn-sandbox/keptn-service-template-go:0.1.1 |
-|       0.7.2      | keptn-sandbox/keptn-service-template-go:0.1.2 |
+| Keptn Version | [Keptn-Service-Template-Go Docker Image](https://hub.docker.com/r/keptn-sandbox/keptn-service-template-go/tags) |
+|:-------------:|:---------------------------------------------------------------------------------------------------------------:|
+|    0.6-0.8    |                                  keptn-sandbox/keptn-service-template-go:0.8.3                                  |
+|    0.10.x     |                                 keptn-sandbox/keptn-service-template-go:0.10.0                                  |
+|    0.11.x     |                                 keptn-sandbox/keptn-service-template-go:0.11.4                                  |
+|    0.12.x     |                                 keptn-sandbox/keptn-service-template-go:0.12.2                                  |
+|    0.13.x     |                                 keptn-sandbox/keptn-service-template-go:0.13.0                                  |
 
 ## Installation
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -13,7 +13,7 @@ distributor:
   image:
     repository: docker.io/keptn/distributor  # Container Image Name
     pullPolicy: IfNotPresent                 # Kubernetes Image Pull Policy
-    tag: "0.12.2"                            # Container Tag
+    tag: "0.13.4"                            # Container Tag
   config:
     queueGroup:
       enabled: true                          # Enable connection via Nats queue group to support exactly-once message processing

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/cloudevents/sdk-go/v2 v2.5.0
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/keptn/go-utils v0.12.0
+	github.com/keptn/go-utils v0.13.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/json-iterator/go v1.1.10 h1:Kz6Cvnvv2wGdaG/V8yMvfkmNiXq9Ya2KUv4rouJJr
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
-github.com/keptn/go-utils v0.12.0 h1:iB/2qDJLt0V2OwkSAD4rH0lKEGlKyYNLzS/ZZ6HKZfY=
-github.com/keptn/go-utils v0.12.0/go.mod h1:yJM7pnCUj23VHKa2az9eWUTAmLDv94f6DVHON9qV1kU=
+github.com/keptn/go-utils v0.13.0 h1:jQ8EoWWa4EPamu4dis+AMzVD4YG2Yu/FEwvpgwslFrE=
+github.com/keptn/go-utils v0.13.0/go.mod h1:yJM7pnCUj23VHKa2az9eWUTAmLDv94f6DVHON9qV1kU=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -23,7 +23,7 @@ deploy:
         overrides:
           distributor:
             image:
-              tag: 0.12.2
+              tag: 0.13.4
           resources:
             limits:
               memory: 512Mi


### PR DESCRIPTION
## This PR

- Upgrades distributor to Keptn 0.13.4
- Upgrades go-utils to v0.13
- Fix/Update compatibility matrix 