### PR TITLE
feat: Upgrade to Keptn 0.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ This implements a keptn-service-template-go for Keptn. If you want to learn more
 |    0.11.x     |                                 keptn-sandbox/keptn-service-template-go:0.11.4                                  |
 |    0.12.x     |                                 keptn-sandbox/keptn-service-template-go:0.12.2                                  |
 |    0.13.x     |                                 keptn-sandbox/keptn-service-template-go:0.13.0                                  |
+|    0.14.x     |                                 keptn-sandbox/keptn-service-template-go:0.14.0                                  |
+
+\* This is the Keptn version we aim to be compatible with. Other versions should work too, but there is no guarantee.
+
+**Note**: Versions compatible with Keptn 0.14.x and newer are not backward compatible due to a change in NATS cluster name
+(see https://github.com/keptn/keptn/releases/tag/0.14.1 for more info about the breaking change).
 
 ## Installation
 

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -74,6 +74,8 @@ spec:
               memory: "128Mi"
               cpu: "500m"
           env:
+            - name: PUBSUB_URL
+              value: 'nats://keptn-nats'
             - name: PUBSUB_TOPIC
               value: {{ .Values.distributor.pubsubTopic }}
             - name: PUBSUB_RECIPIENT

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -13,7 +13,7 @@ distributor:
   image:
     repository: docker.io/keptn/distributor  # Container Image Name
     pullPolicy: IfNotPresent                 # Kubernetes Image Pull Policy
-    tag: "0.13.4"                            # Container Tag
+    tag: "0.14.1"                            # Container Tag
   config:
     queueGroup:
       enabled: true                          # Enable connection via Nats queue group to support exactly-once message processing

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/cloudevents/sdk-go/v2 v2.5.0
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/keptn/go-utils v0.13.0
+	github.com/keptn/go-utils v0.14.0
 	github.com/keptn/kubernetes-utils v0.13.0
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -476,6 +476,8 @@ github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dv
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/keptn/go-utils v0.13.0 h1:jQ8EoWWa4EPamu4dis+AMzVD4YG2Yu/FEwvpgwslFrE=
 github.com/keptn/go-utils v0.13.0/go.mod h1:yJM7pnCUj23VHKa2az9eWUTAmLDv94f6DVHON9qV1kU=
+github.com/keptn/go-utils v0.14.0 h1:1EDbYjKdQdhcvp6ErbDyyR/pd7pa4dksT509/GRzQ24=
+github.com/keptn/go-utils v0.14.0/go.mod h1:CIRwnEp/QYaSBa/r146x3h4yqWB4FS3YNKHzftoyhVA=
 github.com/keptn/kubernetes-utils v0.13.0 h1:tIdmdNobI+L4/b3nJPzMRJ1vRg4oqEEnDGPBHFO/hzs=
 github.com/keptn/kubernetes-utils v0.13.0/go.mod h1:WgPDwDt8QxEoaQXIBE7MmSp6TBDe09/AyAEk7T9r8Og=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -23,7 +23,7 @@ deploy:
         overrides:
           distributor:
             image:
-              tag: 0.13.4
+              tag: 0.14.1
           resources:
             limits:
               memory: 512Mi


### PR DESCRIPTION
## This PR

- Upgrades distributor to Keptn 0.14.1
- Upgrades go-utils to v0.14
- Update compatibility matrix 