### PR TITLE
feat: Handle uppercase repo owners in actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -130,14 +130,21 @@ jobs:
         with:
           env-file: .ci_env
 
+      - name: Sanitize repo owner
+        uses: actions/github-script@v4
+        id: repo_slug
+        with:
+          result-encoding: string
+          script: return '${{ github.repository_owner }}'.toLowerCase()
+
       - name: Docker Build
         id: docker_build
         uses: keptn/gh-automation/.github/actions/docker-build@v1.5.3
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAGS: |
-            ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE }}:${{ env.VERSION }}
-            ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE }}:${{ env.VERSION }}.${{ env.DATETIME }}
+            ghcr.io/${{ steps.repo_slug.outputs.result }}/${{ env.IMAGE }}:${{ env.VERSION }}
+            ghcr.io/${{ steps.repo_slug.outputs.result }}/${{ env.IMAGE }}:${{ env.VERSION }}.${{ env.DATETIME }}
           BUILD_ARGS: |
             version=${{ env.VERSION }}
           PUSH: ${{(github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository)}}

--- a/.github/workflows/initrepo.yml
+++ b/.github/workflows/initrepo.yml
@@ -22,24 +22,18 @@ jobs:
         with:
           go-version: '^1.17.5' # The Go version to download (if necessary) and use.
       - run: go version
-      - name: Sanitize repo owner
-        uses: actions/github-script@v4
-        id: repo_slug
-        with:
-          result-encoding: string
-          script: return '${{ github.repository_owner }}'.toLowerCase()
       - name: Update the image name in .ci_env, helm chart and skaffold
         run: |
           ESCAPED_ORIGINAL=$(printf '%s\n' "$ORIGINAL_IMAGE_NAME" | tr '[:upper:]' '[:lower:]' | sed -e 's/[\/&]/\\&/g')
           ESCAPED_REPLACE=$(printf '%s\n' "$NEW_IMAGE_NAME" | tr '[:upper:]' '[:lower:]' | sed -e 's/[\/&]/\\&/g') 
           sed -i "s/${ESCAPED_ORIGINAL}/${ESCAPED_REPLACE}/g" chart/values.yaml skaffold.yaml chart/README.md
-          NEW_SERVICE_NAME=$(echo ${{ github.repository }} | sed -e 's/${{ steps.repo_slug.outputs.result }}\///')
+          NEW_SERVICE_NAME=$(echo ${{ github.repository }} | sed -e 's/${{ github.repository_owner }}\///')
           ESCAPED_ORIGINAL=$(printf '%s\n' "$ORIGINAL_SERVICE_NAME" | tr '[:upper:]' '[:lower:]' | sed -e 's/[\/&]/\\&/g')
           ESCAPED_REPLACE=$(printf '%s\n' "$NEW_SERVICE_NAME" | tr '[:upper:]' '[:lower:]' | sed -e 's/[\/&]/\\&/g')
           sed -i "s/${ESCAPED_ORIGINAL}/${ESCAPED_REPLACE}/g" skaffold.yaml chart/README.md .ci_env
       - name: Update chart name, version and service name
         run: |
-          NEW_SERVICE_NAME=$(echo ${{ github.repository }} | sed -e 's/${{ steps.repo_slug.outputs.result }}\///')
+          NEW_SERVICE_NAME=$(echo ${{ github.repository }} | sed -e 's/${{ github.repository_owner }}\///')
           ESCAPED_ORIGINAL=$(printf '%s\n' "$ORIGINAL_SERVICE_NAME" | tr '[:upper:]' '[:lower:]' | sed -e 's/[\/&]/\\&/g')
           ESCAPED_REPLACE=$(printf '%s\n' "$NEW_SERVICE_NAME" | tr '[:upper:]' '[:lower:]' | sed -e 's/[\/&]/\\&/g') 
           sed -i "s/${ESCAPED_ORIGINAL}/${ESCAPED_REPLACE}/g" ./**/*.yaml
@@ -47,7 +41,7 @@ jobs:
           sed -irn 's/appVersion:.*$/appVersion: "0.1.0"/g' chart/Chart.yaml
       - name: Update .gitignore, Dockerfile and GetSLI eventhandler
         run: |
-          NEW_SERVICE_NAME=$(echo ${{ github.repository }} | sed -e 's/${{ steps.repo_slug.outputs.result }}\///')
+          NEW_SERVICE_NAME=$(echo ${{ github.repository }} | sed -e 's/${{ github.repository_owner }}\///')
           ESCAPED_ORIGINAL=$(printf '%s\n' "$ORIGINAL_SERVICE_NAME" | sed -e 's/[\/&]/\\&/g')
           ESCAPED_REPLACE=$(printf '%s\n' "$NEW_SERVICE_NAME" | sed -e 's/[\/&]/\\&/g') 
           sed -i "s/${ESCAPED_ORIGINAL}/${ESCAPED_REPLACE}/g" .ci_env .gitignore Dockerfile main.go eventhandlers.go eventhandler_test.go test-events/*.json
@@ -59,7 +53,7 @@ jobs:
           ESCAPED_ORIGINAL=$(printf '%s\n' "$ORIGINAL_REPO_NAME" | tr '[:upper:]' '[:lower:]' | sed -e 's/[\/&]/\\&/g')
           ESCAPED_REPLACE=$(printf '%s\n' "$NEW_REPO_NAME" | tr '[:upper:]' '[:lower:]' | sed -e 's/[\/&]/\\&/g')
           sed -i "s/${ESCAPED_ORIGINAL}/${ESCAPED_REPLACE}/g" README.md
-          NEW_SERVICE_NAME=$(echo ${{ github.repository }} | sed -e 's/${{ steps.repo_slug.outputs.result }}\///')
+          NEW_SERVICE_NAME=$(echo ${{ github.repository }} | sed -e 's/${{ github.repository_owner }}\///')
           ESCAPED_ORIGINAL=$(printf '%s\n' "$ORIGINAL_SERVICE_NAME" | tr '[:upper:]' '[:lower:]' | sed -e 's/[\/&]/\\&/g')
           ESCAPED_REPLACE=$(printf '%s\n' "$NEW_SERVICE_NAME" | tr '[:upper:]' '[:lower:]' | sed -e 's/[\/&]/\\&/g')
           sed -i "s/${ESCAPED_ORIGINAL}/${ESCAPED_REPLACE}/g" README.md
@@ -103,7 +97,7 @@ jobs:
           ESCAPED_ORIGINAL=$(printf '%s\n' "$ORIGINAL_REPO_NAME" | sed -e 's/[\/&]/\\&/g')
           ESCAPED_REPLACE=$(printf '%s\n' "$NEW_REPO_NAME" | sed -e 's/[\/&]/\\&/g')
           find . -type f -not -path '*/.git/*' -not -path '*/.github/*' -print0 | xargs -0 sed -i "s/${ESCAPED_ORIGINAL}/${ESCAPED_REPLACE}/g"
-          NEW_SERVICE_NAME=$(echo ${{ github.repository }} | sed -e 's/${{ steps.repo_slug.outputs.result }}\///')
+          NEW_SERVICE_NAME=$(echo ${{ github.repository }} | sed -e 's/${{ github.repository_owner }}\///')
           ESCAPED_ORIGINAL=$(printf '%s\n' "$ORIGINAL_SERVICE_NAME" | sed -e 's/[\/&]/\\&/g')
           ESCAPED_REPLACE=$(printf '%s\n' "$NEW_SERVICE_NAME" | sed -e 's/[\/&]/\\&/g')
           find . -type f -not -path '*/.git/*' -not -path '*/.github/*' -print0 | xargs -0 sed -i "s/${ESCAPED_ORIGINAL}/${ESCAPED_REPLACE}/g"

--- a/.github/workflows/initrepo.yml
+++ b/.github/workflows/initrepo.yml
@@ -22,18 +22,24 @@ jobs:
         with:
           go-version: '^1.17.5' # The Go version to download (if necessary) and use.
       - run: go version
+      - name: Sanitize repo owner
+        uses: actions/github-script@v4
+        id: repo_slug
+        with:
+          result-encoding: string
+          script: return '${{ github.repository_owner }}'.toLowerCase()
       - name: Update the image name in .ci_env, helm chart and skaffold
         run: |
           ESCAPED_ORIGINAL=$(printf '%s\n' "$ORIGINAL_IMAGE_NAME" | tr '[:upper:]' '[:lower:]' | sed -e 's/[\/&]/\\&/g')
           ESCAPED_REPLACE=$(printf '%s\n' "$NEW_IMAGE_NAME" | tr '[:upper:]' '[:lower:]' | sed -e 's/[\/&]/\\&/g') 
           sed -i "s/${ESCAPED_ORIGINAL}/${ESCAPED_REPLACE}/g" chart/values.yaml skaffold.yaml chart/README.md
-          NEW_SERVICE_NAME=$(echo ${{ github.repository }} | sed -e 's/${{ github.repository_owner }}\///')
+          NEW_SERVICE_NAME=$(echo ${{ github.repository }} | sed -e 's/${{ steps.repo_slug.outputs.result }}\///')
           ESCAPED_ORIGINAL=$(printf '%s\n' "$ORIGINAL_SERVICE_NAME" | tr '[:upper:]' '[:lower:]' | sed -e 's/[\/&]/\\&/g')
           ESCAPED_REPLACE=$(printf '%s\n' "$NEW_SERVICE_NAME" | tr '[:upper:]' '[:lower:]' | sed -e 's/[\/&]/\\&/g')
           sed -i "s/${ESCAPED_ORIGINAL}/${ESCAPED_REPLACE}/g" skaffold.yaml chart/README.md .ci_env
       - name: Update chart name, version and service name
         run: |
-          NEW_SERVICE_NAME=$(echo ${{ github.repository }} | sed -e 's/${{ github.repository_owner }}\///')
+          NEW_SERVICE_NAME=$(echo ${{ github.repository }} | sed -e 's/${{ steps.repo_slug.outputs.result }}\///')
           ESCAPED_ORIGINAL=$(printf '%s\n' "$ORIGINAL_SERVICE_NAME" | tr '[:upper:]' '[:lower:]' | sed -e 's/[\/&]/\\&/g')
           ESCAPED_REPLACE=$(printf '%s\n' "$NEW_SERVICE_NAME" | tr '[:upper:]' '[:lower:]' | sed -e 's/[\/&]/\\&/g') 
           sed -i "s/${ESCAPED_ORIGINAL}/${ESCAPED_REPLACE}/g" ./**/*.yaml
@@ -41,7 +47,7 @@ jobs:
           sed -irn 's/appVersion:.*$/appVersion: "0.1.0"/g' chart/Chart.yaml
       - name: Update .gitignore, Dockerfile and GetSLI eventhandler
         run: |
-          NEW_SERVICE_NAME=$(echo ${{ github.repository }} | sed -e 's/${{ github.repository_owner }}\///')
+          NEW_SERVICE_NAME=$(echo ${{ github.repository }} | sed -e 's/${{ steps.repo_slug.outputs.result }}\///')
           ESCAPED_ORIGINAL=$(printf '%s\n' "$ORIGINAL_SERVICE_NAME" | sed -e 's/[\/&]/\\&/g')
           ESCAPED_REPLACE=$(printf '%s\n' "$NEW_SERVICE_NAME" | sed -e 's/[\/&]/\\&/g') 
           sed -i "s/${ESCAPED_ORIGINAL}/${ESCAPED_REPLACE}/g" .ci_env .gitignore Dockerfile main.go eventhandlers.go eventhandler_test.go test-events/*.json
@@ -53,7 +59,7 @@ jobs:
           ESCAPED_ORIGINAL=$(printf '%s\n' "$ORIGINAL_REPO_NAME" | tr '[:upper:]' '[:lower:]' | sed -e 's/[\/&]/\\&/g')
           ESCAPED_REPLACE=$(printf '%s\n' "$NEW_REPO_NAME" | tr '[:upper:]' '[:lower:]' | sed -e 's/[\/&]/\\&/g')
           sed -i "s/${ESCAPED_ORIGINAL}/${ESCAPED_REPLACE}/g" README.md
-          NEW_SERVICE_NAME=$(echo ${{ github.repository }} | sed -e 's/${{ github.repository_owner }}\///')
+          NEW_SERVICE_NAME=$(echo ${{ github.repository }} | sed -e 's/${{ steps.repo_slug.outputs.result }}\///')
           ESCAPED_ORIGINAL=$(printf '%s\n' "$ORIGINAL_SERVICE_NAME" | tr '[:upper:]' '[:lower:]' | sed -e 's/[\/&]/\\&/g')
           ESCAPED_REPLACE=$(printf '%s\n' "$NEW_SERVICE_NAME" | tr '[:upper:]' '[:lower:]' | sed -e 's/[\/&]/\\&/g')
           sed -i "s/${ESCAPED_ORIGINAL}/${ESCAPED_REPLACE}/g" README.md
@@ -97,7 +103,7 @@ jobs:
           ESCAPED_ORIGINAL=$(printf '%s\n' "$ORIGINAL_REPO_NAME" | sed -e 's/[\/&]/\\&/g')
           ESCAPED_REPLACE=$(printf '%s\n' "$NEW_REPO_NAME" | sed -e 's/[\/&]/\\&/g')
           find . -type f -not -path '*/.git/*' -not -path '*/.github/*' -print0 | xargs -0 sed -i "s/${ESCAPED_ORIGINAL}/${ESCAPED_REPLACE}/g"
-          NEW_SERVICE_NAME=$(echo ${{ github.repository }} | sed -e 's/${{ github.repository_owner }}\///')
+          NEW_SERVICE_NAME=$(echo ${{ github.repository }} | sed -e 's/${{ steps.repo_slug.outputs.result }}\///')
           ESCAPED_ORIGINAL=$(printf '%s\n' "$ORIGINAL_SERVICE_NAME" | sed -e 's/[\/&]/\\&/g')
           ESCAPED_REPLACE=$(printf '%s\n' "$NEW_SERVICE_NAME" | sed -e 's/[\/&]/\\&/g')
           find . -type f -not -path '*/.git/*' -not -path '*/.github/*' -print0 | xargs -0 sed -i "s/${ESCAPED_ORIGINAL}/${ESCAPED_REPLACE}/g"

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -31,11 +31,18 @@ jobs:
         with:
           env-file: .ci_env
 
+      - name: Sanitize repo owner
+        uses: actions/github-script@v4
+        id: repo_slug
+        with:
+          result-encoding: string
+          script: return '${{ github.repository_owner }}'.toLowerCase()
+
       - name: Docker Build
         uses: keptn/gh-automation/.github/actions/docker-build@v1.5.3
         with:
           TAGS: |
-            ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE }}:${{ env.VERSION }}
+            ghcr.io/${{ steps.repo_slug.outputs.result }}/${{ env.IMAGE }}:${{ env.VERSION }}
           BUILD_ARGS: |
             version=${{ env.VERSION }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,11 +31,18 @@ jobs:
         with:
           env-file: .ci_env
 
+      - name: Sanitize repo owner
+        uses: actions/github-script@v4
+        id: repo_slug
+        with:
+          result-encoding: string
+          script: return '${{ github.repository_owner }}'.toLowerCase()
+
       - name: Docker Build
         uses: keptn/gh-automation/.github/actions/docker-build@v1.5.3
         with:
           TAGS: |
-            ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE }}:${{ env.VERSION }}
+            ghcr.io/${{ steps.repo_slug.outputs.result }}/${{ env.IMAGE }}:${{ env.VERSION }}
           BUILD_ARGS: |
             version=${{ env.VERSION }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## This PR

- Sanitizes upper-case `repository_owner` names (turns them into lower-case)
- Uses the lower-case names in all affected workflows

### Proof of work

I tried the `CI` action in my fork (`repository_owner=TannerGabriel`) and got the following results:
![keptn-service-template-uppercase-repo-name](https://user-images.githubusercontent.com/40315960/168018013-fe5708a7-7880-48c0-a98a-4053338f2408.png)

**Resolves:** #118 