### PR TITLE
fix: Remove unsupported Keptn versions from integration tests

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        keptn-version: [ "0.12.7", "0.13.5", "0.14.2", "0.15.0" ] # https://github.com/keptn/keptn/releases
+        keptn-version: [ "0.14.2", "0.15.0" ] # https://github.com/keptn/keptn/releases
     env:
       GO_VERSION: 1.17
       GO111MODULE: "on"


### PR DESCRIPTION
This PR removes Keptn versions `0.12` and `0.13` from the integration test matrix because they are incompatible after breaking changes in [Keptn 0.14](https://github.com/keptn/keptn/releases/tag/0.14.1).