### PR TITLE
feat: Improve integration test pipeline with a gitea provisioner

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -16,13 +16,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        keptn-version: ["0.14.2", "0.15.0"] # https://github.com/keptn/keptn/releases
+        keptn-version: ["0.14.2", "0.15.1", "0.16.0"] # https://github.com/keptn/keptn/releases
     env:
       GO111MODULE: "on"
       ENABLE_E2E_TEST: true
       BRANCH: ${{ github.head_ref || github.ref_name }}
       KUBECONFIG: /etc/rancher/k3s/k3s.yaml
       GOPROXY: "https://proxy.golang.org"
+      GITEA_ADMIN_USERNAME: GiteaAdmin
+      GITEA_NAMESPACE: gitea
     steps:
       - name: Checkout code
         uses: actions/checkout@v3.0.2
@@ -31,6 +33,10 @@ jobs:
         uses: actions/setup-go@v3.2.0
         with:
           go-version-file: "go.mod"
+
+      - name: Install gotestsum
+        shell: bash
+        run: go install gotest.tools/gotestsum@latest
 
       - name: Load CI Environment from .ci_env
         id: load_ci_env
@@ -67,33 +73,104 @@ jobs:
           done;
           echo "K3s ready!!!"
 
+      - name: Generate Gitea credentials
+        id: gitea_credentials
+        run: |
+          password=$(date +%s | sha256sum | base64 | head -c 32)
+          echo "::add-mask::$password"
+          echo "::set-output name=GITEA_ADMIN_PASSWORD::$password"
+
+      - name: Install Gitea
+        id: gitea
+        env:
+          GITEA_ADMIN_PASSWORD: ${{ steps.gitea_credentials.outputs.GITEA_ADMIN_PASSWORD }}
+        run: |
+          export GITEA_ENDPOINT="http://gitea-http.${GITEA_NAMESPACE}:3000"
+          
+          helm repo add gitea-charts https://dl.gitea.io/charts/
+          helm repo update
+          helm install -n ${GITEA_NAMESPACE} gitea gitea-charts/gitea \
+            --create-namespace \
+            --set memcached.enabled=false \
+            --set postgresql.enabled=false \
+            --set gitea.config.database.DB_TYPE=sqlite3 \
+            --set gitea.admin.username=${GITEA_ADMIN_USERNAME} \
+            --set gitea.admin.password=${GITEA_ADMIN_PASSWORD} \
+            --set gitea.config.server.OFFLINE_MODE=true \
+            --set gitea.config.server.ROOT_URL=${GITEA_ENDPOINT}/ \
+            --wait
+          
+          # Export Gitea connection details
+          echo "::set-output name=GITEA_ENDPOINT::${GITEA_ENDPOINT}"
+
+      - name: Install gitea provisioner-service
+        env:
+          GITEA_ADMIN_PASSWORD: ${{ steps.gitea_credentials.outputs.GITEA_ADMIN_PASSWORD }}
+          GITEA_ENDPOINT: ${{ steps.gitea.outputs.GITEA_ENDPOINT }}
+        run: |
+          helm install keptn-gitea-provisioner-service https://github.com/keptn-sandbox/keptn-gitea-provisioner-service/releases/download/0.1.0/keptn-gitea-provisioner-service-0.1.0.tgz \
+            --set gitea.endpoint=${GITEA_ENDPOINT} \
+            --set gitea.admin.create=true \
+            --set gitea.admin.username=${GITEA_ADMIN_USERNAME} \
+            --set gitea.admin.password=${GITEA_ADMIN_PASSWORD}
+
       - name: Install Keptn
         id: install_keptn
-        uses: keptn-sandbox/action-install-keptn@v1.0.0
-        timeout-minutes: 10
+        uses: keptn-sandbox/action-install-keptn@v2.0.0
+        timeout-minutes: 5
         with:
           KEPTN_VERSION: ${{ matrix.keptn-version }}
-          KEPTN_INSTALL_PARAMETERS: -v --endpoint-service-type=LoadBalancer
+          HELM_VALUES: |
+            control-plane:
+              apiGatewayNginx:
+                type: LoadBalancer
+              features:
+                automaticProvisioningURL: http://keptn-gitea-provisioner-service.default
           KUBECONFIG: ${{ env.KUBECONFIG }}
 
       - name: Test connection to keptn
         run: |
-          curl -X GET "${{ steps.install_keptn.outputs.KEPTN_ENDPOINT }}/v1/metadata" -H  "accept: application/json" -H  "x-token: ${{ steps.install_keptn.outputs.KEPTN_API_TOKEN }}"
+          curl -X GET "${{ steps.install_keptn.outputs.KEPTN_API_URL }}/v1/metadata" -H  "accept: application/json" -H  "x-token: ${{ steps.install_keptn.outputs.KEPTN_API_TOKEN }}"
 
-      # Install service from downloaded helm chart
+      # Install service from downloaded helm chart artifact
       - name: Install service
         run: |
           helm upgrade --install --create-namespace -n keptn ${{ env.IMAGE }} \
             ./dist/helm-charts/*.tgz \
             --wait
 
-      - name: Install gotestsum
-        shell: bash
-        run: go install gotest.tools/gotestsum@latest
+      # If we failed any previous step we might have a problem and not reporting anything for the version
+      - name: Create pipeline failure report
+        if: failure()
+        run: |
+          echo "Failed to run integration tests!"
+          echo '{"Test": "TestGitHub Pipeline", "Action": "fail"}' >> $TEST_REPORT_FILENAME
 
       - name: Run integration tests
         env:
-          KEPTN_ENDPOINT: ${{ steps.install_keptn.outputs.KEPTN_ENDPOINT }}
+          KEPTN_ENDPOINT: ${{ steps.install_keptn.outputs.KEPTN_API_URL }}
           KEPTN_API_TOKEN: ${{ steps.install_keptn.outputs.KEPTN_API_TOKEN }}
         shell: bash
         run: gotestsum ./test/e2e/...
+
+
+      - name: Dump k8s debug info
+        if: always()
+        run: |
+          mkdir k8s_debug
+          kubectl describe nodes > k8s_debug/k8s_describe_nodes.txt
+          kubectl cluster-info dump > k8s_debug/k8s_cluster_info_dump.txt
+          kubectl get all -n keptn -o json > k8s_debug/k8s_keptn_objects.json
+          kubectl get configmaps,deployments,pods,networkpolicy,serviceaccounts,role,rolebindings,events -n ${JES_NAMESPACE} -o json > k8s_debug/k8s_jes_objects.json
+          kubectl logs -n keptn -l app.kubernetes.io/instance=keptn --prefix=true --previous=false --all-containers > k8s_debug/k8s_keptn_logs.txt || true
+          kubectl logs deployment/keptn-gitea-provisioner-service --prefix=true --previous=false --all-containers > k8s_debug/k8s_gitea_provisioner_logs.txt
+          kubectl get statefulsets,configmaps,pods,networkpolicy,serviceaccounts,role,rolebindings,events,services -n ${GITEA_NAMESPACE} -o json > k8s_debug/k8s_objects_gitea.json
+          kubectl logs statefulsets/gitea --prefix=true --previous=false --all-containers -n ${GITEA_NAMESPACE} > k8s_debug/k8s_logs_gitea.txt
+
+      # Upload the k8s debug archive, so we can use it for investigating
+      - name: Upload k8s debug archive
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: k8s-debug-archive-${{matrix.keptn-version}}
+          path: k8s_debug/

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -55,7 +55,7 @@ jobs:
           branch: ${{ env.BRANCH }}
           path: ./dist
 
-      # Prepare K3d + Keptn environment
+      # Prepare K3s
       - name: Install and start K3s
         run: |
           curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="v1.21.12+k3s1" INSTALL_K3S_EXEC="--no-deploy traefik" K3S_KUBECONFIG_MODE="644" sh -
@@ -161,7 +161,6 @@ jobs:
           kubectl describe nodes > k8s_debug/k8s_describe_nodes.txt
           kubectl cluster-info dump > k8s_debug/k8s_cluster_info_dump.txt
           kubectl get all -n keptn -o json > k8s_debug/k8s_keptn_objects.json
-          kubectl get configmaps,deployments,pods,networkpolicy,serviceaccounts,role,rolebindings,events -n ${JES_NAMESPACE} -o json > k8s_debug/k8s_jes_objects.json
           kubectl logs -n keptn -l app.kubernetes.io/instance=keptn --prefix=true --previous=false --all-containers > k8s_debug/k8s_keptn_logs.txt || true
           kubectl logs deployment/keptn-gitea-provisioner-service --prefix=true --previous=false --all-containers > k8s_debug/k8s_gitea_provisioner_logs.txt
           kubectl get statefulsets,configmaps,pods,networkpolicy,serviceaccounts,role,rolebindings,events,services -n ${GITEA_NAMESPACE} -o json > k8s_debug/k8s_objects_gitea.json

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -112,7 +112,8 @@ jobs:
             --set gitea.endpoint=${GITEA_ENDPOINT} \
             --set gitea.admin.create=true \
             --set gitea.admin.username=${GITEA_ADMIN_USERNAME} \
-            --set gitea.admin.password=${GITEA_ADMIN_PASSWORD}
+            --set gitea.admin.password=${GITEA_ADMIN_PASSWORD} \
+            --wait
 
       - name: Install Keptn
         id: install_keptn
@@ -162,9 +163,9 @@ jobs:
           kubectl cluster-info dump > k8s_debug/k8s_cluster_info_dump.txt
           kubectl get all -n keptn -o json > k8s_debug/k8s_keptn_objects.json
           kubectl logs -n keptn -l app.kubernetes.io/instance=keptn --prefix=true --previous=false --all-containers > k8s_debug/k8s_keptn_logs.txt || true
-          kubectl logs deployment/keptn-gitea-provisioner-service --prefix=true --previous=false --all-containers > k8s_debug/k8s_gitea_provisioner_logs.txt
+          kubectl logs deployment/keptn-gitea-provisioner-service --prefix=true --previous=false --all-containers > k8s_debug/k8s_gitea_provisioner_logs.txt || true
           kubectl get statefulsets,configmaps,pods,networkpolicy,serviceaccounts,role,rolebindings,events,services -n ${GITEA_NAMESPACE} -o json > k8s_debug/k8s_objects_gitea.json
-          kubectl logs statefulsets/gitea --prefix=true --previous=false --all-containers -n ${GITEA_NAMESPACE} > k8s_debug/k8s_logs_gitea.txt
+          kubectl logs statefulsets/gitea --prefix=true --previous=false --all-containers -n ${GITEA_NAMESPACE} > k8s_debug/k8s_logs_gitea.txt || true
 
       # Upload the k8s debug archive, so we can use it for investigating
       - name: Upload k8s debug archive

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Quick start:
 
 1. In case you want to contribute your service to keptn-sandbox or keptn-contrib, make sure you have read and understood the [Contributing Guidelines](https://github.com/keptn-sandbox/contributing).
 1. Click [Use this template](https://github.com/keptn-sandbox/keptn-service-template-go/generate) on top of the repository, or download the repo as a zip-file, extract it into a new folder named after the service you want to create (e.g., simple-service) 
-1. Run GitHub workflow `One-time repository initialization` to tailor deployment files and go modules to the new instance of the keptn service template. This will create a Pull Request containing the necessary changes, review it, adjust if necessary and merge it.
+1. **Required**: Run GitHub workflow `One-time repository initialization` to tailor deployment files and go modules to the new instance of the keptn service template. This will create a Pull Request containing the necessary changes, review it, adjust if necessary and merge it.
 1. Figure out whether your Kubernetes Deployment requires [any RBAC rules or a different service-account](https://github.com/keptn-sandbox/contributing#rbac-guidelines), and adapt [chart/templates/serviceaccount.yaml](chart/templates/serviceaccount.yaml) accordingly for the roles.
 1. Last but not least: Remove this intro within the README file and make sure the README file properly states what this repository is about
 
@@ -88,9 +88,9 @@ Development can be conducted using any GoLang compatible IDE/editor (e.g., Jetbr
 It is recommended to make use of branches as follows:
 
 * `main`/`master` contains the latest potentially unstable version
-* `release-*` contains a stable version of the service (e.g., `release-0.1.0` contains version 0.1.0)
+* releases are handled via git tags (and GitHub releases)
 * create a new branch for any changes that you are working on, e.g., `feature/my-cool-stuff` or `bug/overflow`
-* once ready, create a pull request from that branch back to the `main`/`master` branch
+* once ready, create a pull request from your branch back to the `main`/`master` branch
 
 When writing code, it is recommended to follow the coding style suggested by the [Golang community](https://github.com/golang/go/wiki/CodeReviewComments).
 
@@ -113,9 +113,6 @@ If you want to get more insights into processing those CloudEvents or even defin
 * Build the docker image: `docker build . -t keptn-sandbox/keptn-service-template-go:dev` (Note: Ensure that you use the correct DockerHub account/organization)
 * Run the docker image locally: `docker run --rm -it -p 8080:8080 keptn-sandbox/keptn-service-template-go:dev`
 * Push the docker image to DockerHub: `docker push keptn-sandbox/keptn-service-template-go:dev` (Note: Ensure that you use the correct DockerHub account/organization)
-* Deploy the service using `kubectl`: `kubectl apply -f deploy/`
-* Delete/undeploy the service using `kubectl`: `kubectl delete -f deploy/`
-* Watch the deployment using `kubectl`: `kubectl -n keptn get deployment keptn-service-template-go -o wide`
 * Get logs using `kubectl`: `kubectl -n keptn logs deployment/keptn-service-template-go -f`
 * Watch the deployed pods using `kubectl`: `kubectl -n keptn get pods -l run=keptn-service-template-go`
 * Deploy the service using [Skaffold](https://skaffold.dev/): `skaffold run --default-repo=your-docker-registry --tail` (Note: Replace `your-docker-registry` with your container image registry (defaults to ghcr.io/keptn-sandbox/keptn-service-template-go); also make sure to adapt the image name in [skaffold.yaml](skaffold.yaml))

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -47,8 +47,7 @@
             ],
             "properties": {
               "hostname": {
-                "pattern": "^[a-z0-9][a-z0-9-.]{2,63}$"
-              },
+                "pattern": "^[a-z0-9][a-z0-9-.]{2,63}(:[0-9]+)?$"              },
               "protocol": {
                 "enum": [
                   "http",

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -21,9 +21,6 @@ deploy:
         imageStrategy:
           helm: { }
         overrides:
-          distributor:
-            image:
-              tag: 0.14.1
           resources:
             limits:
               memory: 512Mi


### PR DESCRIPTION
This PR levels up our integration test pipeline for the service template.

- We now include the brand new gitea provisioner
- We also include the brand new keptn-install-action
- I added Kubernetes log output and the debug archive, because it's awesome for troubleshooting
- I updated the Keptn versions we test against
- Update helm chart values hostname pattern to allow `host(:port)` combinations
- Removed distributor version from skaffold.yaml as it's redundant with what we have in helm chart values.yaml

Integration Test Run: https://github.com/keptn-sandbox/keptn-service-template-go/actions/runs/2582718669



