### PR TITLE
fix: Use global logrus logger instead of new one

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,6 +34,6 @@ func main() {
 		sdk.WithTaskHandler(
 			getSliTriggeredEvent,
 			handler.NewGetSliEventHandler()),
-		sdk.WithLogger(logrus.New()),
+		sdk.WithLogger(logrus.StandardLogger()),
 	).Start())
 }


### PR DESCRIPTION
This PR contains changes to use the global logger (obtained via `logrus.StandardLogger()`) instead of a new one to ensure that the configured log level is also used from logs originating from the go sdk components.

Signed-off-by: warber <bernd.warmuth@dynatrace.com>